### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,8 +5,8 @@
 ##################################################
 
 LCD1602KeyPad	KEYWORD1
-ButtonKey KEYWORD1
-ButtonState KEYWORD1
+ButtonKey	KEYWORD1
+ButtonState	KEYWORD1
 
 ##################################################
 # Datatypes (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords